### PR TITLE
merge qkv matrices

### DIFF
--- a/train_llama.py
+++ b/train_llama.py
@@ -133,9 +133,12 @@ class Attention(nn.Module):
         self.n_local_kv_heads = self.n_kv_heads // model_parallel_size
         self.n_rep = self.n_local_heads // self.n_local_kv_heads
         self.head_dim = args.dim // args.n_heads
-        self.wq = nn.Linear(args.dim, args.n_heads * self.head_dim, bias=False)
-        self.wk = nn.Linear(args.dim, self.n_kv_heads * self.head_dim, bias=False)
-        self.wv = nn.Linear(args.dim, self.n_kv_heads * self.head_dim, bias=False)
+        
+        hdim = args.n_heads * self.head_dim
+        std = 0.5 * (args.dim ** -0.5)
+        bound = (3 ** 0.5) * std
+        self.qkv_w = nn.Parameter(torch.empty(3, hdim, args.dim).uniform_(-bound, bound))
+        
         self.wo = nn.Linear(args.n_heads * self.head_dim, args.dim, bias=False)
         self.attn_dropout = nn.Dropout(args.dropout)
         self.resid_dropout = nn.Dropout(args.dropout)
@@ -153,10 +156,11 @@ class Attention(nn.Module):
     ):
         bsz, seqlen, _ = x.shape
 
-        xq, xk, xv = self.wq(x), self.wk(x), self.wv(x)
-        xq = xq.view(bsz, seqlen, self.n_local_heads, self.head_dim)
-        xk = xk.view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
-        xv = xv.view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
+        qkv = F.linear(x, self.qkv_w.flatten(end_dim=1).type_as(x))
+        xq, xk, xv = qkv.view(bsz, seqlen, 3 * self.n_local_heads, self.head_dim).chunk(3, dim=-2)
+        xq = xq.contiguous().view(bsz, seqlen, self.n_local_heads, self.head_dim)
+        xk = xk.contiguous().view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
+        xv = xv.contiguous().view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
 
         xq, xk = apply_rotary_emb(xq, xk, freqs_cos, freqs_sin)
         xk = repeat_kv(xk, self.n_rep)
@@ -357,7 +361,7 @@ class TrainingConfig:
     # Optimizer
     gradient_accumulation_steps: int = 4
     learning_rate: float = 1e-3
-    max_iters: int = 201
+    max_iters: int = 101
     weight_decay: float = 0.0
     beta1: float = 0.8
     beta2: float = 0.95


### PR DESCRIPTION
```
tokens per iteration: 65,536
breakdown: config.gradient_accumulation_steps=1 * ddp_world_size=4 * config.batch_size=16 * config.max_seq_len=1024
total params: 6,682,124,288 parameters
  Muon (2D weights): 128 tensors, 4,865,392,640 parameters
  AdamW (others): 98 tensors, 1,816,731,648 parameters
Muon lr: 0.05, AdamW lr: 0.001
using fused AdamW: True
Python 3.11.10 (main, Dec  3 2024, 02:25:00) [GCC 12.2.0]
PyTorch 2.10.0.dev20251003+cu128 (CUDA 12.8)
Sun Oct  5 19:44:53 2025
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 575.57.08              Driver Version: 575.57.08      CUDA Version: 12.9     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
| N/A   39C    P0            121W /  700W |   26661MiB /  81559MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   1  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
| N/A   37C    P0            117W /  700W |   25643MiB /  81559MiB |     32%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   2  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
| N/A   39C    P0            118W /  700W |   26675MiB /  81559MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   3  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
| N/A   36C    P0            117W /  700W |   27225MiB /  81559MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|    0   N/A  N/A               1      C   /bin/dumb-init                        26652MiB |
|    1   N/A  N/A               1      C   /bin/dumb-init                        26150MiB |
|    2   N/A  N/A               1      C   /bin/dumb-init                        26722MiB |
|    3   N/A  N/A               1      C   /bin/dumb-init                        27216MiB |
+-----------------------------------------------------------------------------------------+

step 0: train loss 11.6675, val loss 11.6613
0 | loss 11.6875 | lr 1.000000e-03 | 94321.78ms
10 | loss 9.1875 | lr 1.000000e-03 | 3479.80ms
20 | loss 9.5625 | lr 1.000000e-03 | 3498.97ms
30 | loss 8.3750 | lr 1.000000e-03 | 3511.68ms
40 | loss 7.7188 | lr 1.000000e-03 | 3514.13ms
50 | loss 7.4375 | lr 1.000000e-03 | 3523.38ms
60 | loss 7.0000 | lr 9.118812e-04 | 3529.13ms
70 | loss 7.0625 | lr 7.138614e-04 | 3527.50ms
80 | loss 5.9375 | lr 5.158416e-04 | 3519.55ms
90 | loss 6.7500 | lr 3.178218e-04 | 3519.44ms
step 100: train loss 6.4956, val loss 6.4706
100 | loss 6.0625 | lr 1.198020e-04 | 90926.85ms
Return code: 0
```

- improves step time by ~300 ms
- does not improve rate of convergence. not sure why, it should be "equivalent" to if the matrices were separate. likely due to uniform init?