### PR TITLE
Add flex attention

### DIFF
--- a/train_llama.py
+++ b/train_llama.py
@@ -22,6 +22,10 @@ import torch.nn.functional as F
 from torch.distributed import destroy_process_group, init_process_group
 from torch.distributed.fsdp import fully_shard, MixedPrecisionPolicy, FSDPModule
 from torch.utils.checkpoint import checkpoint
+from torch.nn.attention.flex_attention import flex_attention, create_block_mask
+
+# Compile flex_attention once at module level
+flex_attention_compiled = torch.compile(flex_attention)
 
 
 def _load_data_shard(filename):
@@ -139,9 +143,17 @@ class Attention(nn.Module):
 
         self.wo = nn.Linear(args.n_heads * self.head_dim, args.dim, bias=False)
 
-        mask = torch.full((1, 1, args.max_seq_len, args.max_seq_len), float("-inf"))
-        mask = torch.triu(mask, diagonal=1)
-        self.register_buffer("mask", mask)
+    def _create_causal_block_mask(self, batch_size: int, seq_len: int):
+        """Create a simple causal block mask for FlexAttention."""
+        def score_mod(score, b, h, q_idx, kv_idx):
+            return torch.where(q_idx >= kv_idx, score, -float("inf"))
+        
+        def mask_mod(b, h, q_idx, kv_idx):
+            return q_idx >= kv_idx
+        
+        block_mask = create_block_mask(mask_mod, B=batch_size, H=None, 
+                                     Q_LEN=seq_len, KV_LEN=seq_len)
+        return score_mod, block_mask
 
     def forward(
         self,
@@ -165,11 +177,11 @@ class Attention(nn.Module):
         xk = xk.transpose(1, 2)
         xv = xv.transpose(1, 2)
 
-        scores = torch.matmul(xq, xk.transpose(2, 3)) / math.sqrt(self.head_dim)
-        assert hasattr(self, "mask")
-        scores = scores + self.mask[:, :, :seqlen, :seqlen]
-        scores = F.softmax(scores.float(), dim=-1).type_as(xq)
-        output = torch.matmul(scores, xv)
+        # Create causal block mask for FlexAttention
+        score_mod, block_mask = self._create_causal_block_mask(bsz, seqlen)
+        
+        # Use compiled FlexAttention instead of manual attention computation
+        output = flex_attention_compiled(xq, xk, xv, score_mod=score_mod, block_mask=block_mask)
 
         output = output.transpose(1, 2).contiguous().view(bsz, seqlen, -1)
         output = self.wo(output)
@@ -332,7 +344,7 @@ class TrainingConfig:
     eval_only: bool = False
 
     # Data
-    batch_size: int = 16
+    batch_size: int = 8
     max_seq_len: int = 1024
     train_data_path: str = "data/fineweb10B/fineweb_train_*.bin"
     val_data_path: str = "data/fineweb10B/fineweb_val_*.bin"
@@ -363,7 +375,7 @@ class TrainingConfig:
     # System
     device: str = "cuda"
     dtype: str = "bfloat16"
-    compile: bool = False
+    compile: bool = True
 
     def __post_init__(self):
         self.lr_decay_iters = self.max_iters
@@ -441,7 +453,7 @@ muon_optimizer, adamw_optimizer = optimizers
 if config.compile:
     if master_process:
         print("compiling the model... (takes a ~minute)")
-    model = torch.compile(model)
+    model = torch.compile(model, dynamic=False)
 
 
 @torch.no_grad()
@@ -489,7 +501,6 @@ if master_process:
 # training loop
 X, Y = train_loader.next_batch()
 t0 = time.time()
-raw_model = model
 
 for iter_num in range(iter_num, config.max_iters):
     lr = get_lr(iter_num) * config.learning_rate if config.decay_lr else config.learning_rate


### PR DESCRIPTION
flex attention slows down steps quite a bit. why?

```
tokens per iteration: 32,768
breakdown: config.gradient_accumulation_steps=1 * ddp_world_size=4 * config.batch_size=8 * config.max_seq_len=1024
total params: 6,682,124,288 parameters
  Muon (2D weights): 160 tensors, 6,476,005,376 parameters
  AdamW (others): 66 tensors, 206,118,912 parameters
Muon lr: 0.05, AdamW lr: 0.001
using fused AdamW: True
compiling the model... (takes a ~minute)
Python 3.11.10 (main, Dec  3 2024, 02:25:00) [GCC 12.2.0]
PyTorch 2.10.0.dev20251003+cu128 (CUDA 12.8)
Sun Oct  5 23:22:28 2025
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 575.57.08              Driver Version: 575.57.08      CUDA Version: 12.9     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                  Off |
| N/A   29C    P0            123W /  700W |   26505MiB /  81559MiB |      8%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   1  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                  Off |
| N/A   39C    P0            129W /  700W |   27069MiB /  81559MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   2  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                  Off |
| N/A   54C    P0            136W /  700W |   27069MiB /  81559MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   3  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                  Off |
| N/A   43C    P0            131W /  700W |   27069MiB /  81559MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
|        ID   ID                                                               Usage      | |=========================================================================================|
|    0   N/A  N/A               1      C   /bin/dumb-init                        26496MiB |
|    1   N/A  N/A               1      C   /bin/dumb-init                        27060MiB |
|    2   N/A  N/A               1      C   /bin/dumb-init                        27060MiB | |    3   N/A  N/A               1      C   /bin/dumb-init                        27060MiB |
+-----------------------------------------------------------------------------------------+

[gpu-health] [WARN] GPU-56d029b5-5877-651f-af2c-441dae48f056: DCGM dmon: DCGM metrics unhealthy: temp_c=90 (> 89C)
step 0: train loss 11.6287, val loss 11.6275
0 | loss 11.6250 | lr 1.000000e-03 | 82238.37ms
10 | loss 11.0000 | lr 1.000000e-03 | 4423.94ms
20 | loss 9.3750 | lr 1.000000e-03 | 4590.28ms                                              30 | loss 7.4062 | lr 1.000000e-03 | 4647.64ms
40 | loss 7.4062 | lr 1.000000e-03 | 4538.91ms
50 | loss 7.0625 | lr 1.000000e-03 | 4446.04ms
60 | loss 7.4375 | lr 9.118812e-04 | 4618.15ms                                              70 | loss 5.2812 | lr 7.138614e-04 | 4732.52ms
80 | loss 6.8125 | lr 5.158416e-04 | 4747.16ms
90 | loss 6.2812 | lr 3.178218e-04 | 4298.14ms
step 100: train loss 6.3869, val loss 6.3212                                                100 | loss 6.1250 | lr 1.198020e-04 | 80232.13ms
Return code: 0
```